### PR TITLE
fix cron with TZ

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   triggers {
-    cron(BRANCH_NAME == 'master' ? 'H H(0-1) * * *' : '')
+    cron(BRANCH_NAME == 'master' ? 'TZ=America/Chicago\nH H(0-1) * * *' : '')
   }
   agent {
     label "jenkins-jx-base"


### PR DESCRIPTION
as defined in the docs: ```This behavior can optionally be changed by specifying an alternative time zone in the first line of the field. Time zone specification starts with TZ=, followed by the ID of a time zone.```

This wasn't picked up before in https://github.com/AmFamLabs/builder-python/blob/7f2fbbf3f438c09c7d9069ebd7fb9a072a3c2d92/Jenkinsfile#L3-L6 

*because the first line is empty*

```groovy
  cron '''\
  TZ=America/Chicago
  @midnight
  '''
```
would also work because the newline is escaped (with `\`)