### PR TITLE
troubleshoot docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# via https://github.com/jenkins-x/jenkins-x-builders/releases
 FROM jenkinsxio/builder-python:0.1.268
 
 # install vault

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkinsxio/builder-base:latest
 
 RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+RUN package-cleanup --cleandupes
 RUN yum update  -y
 RUN yum install -y python36u python36u-libs python36u-devel python36u-pip
 RUN ln -s /usr/bin/python3.6 /usr/bin/python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM jenkinsxio/builder-base:latest
-
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-RUN yum distribution-synchronization
-RUN yum update  -y
-RUN yum install -y python36u python36u-libs python36u-devel python36u-pip
-RUN ln -s /usr/bin/python3.6 /usr/bin/python3
-# NOTE: jenkinsxio/builder-python original image ends about here...
+FROM jenkinsxio/builder-python:0.1.268
 
 # install vault
 RUN cd /tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkinsxio/builder-base:latest
 
 RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-RUN package-cleanup --cleandupes
+RUN yum distribution-synchronization
 RUN yum update  -y
 RUN yum install -y python36u python36u-libs python36u-devel python36u-pip
 RUN ln -s /usr/bin/python3.6 /usr/bin/python3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,4 @@
 pipeline {
-  triggers {
-    cron(BRANCH_NAME == 'master' ? 'TZ=America/Chicago\n@midnight' : '')
-  }
   agent {
     label "jenkins-jx-base"
   }


### PR DESCRIPTION
Three changes I'm proposing:

1. extend builder-python—not builder-base. https://github.com/jenkins-x/jenkins-x-builders runs builds all builders multiple times per day—not just builder-base like we saw months ago when we first set this repo up.
2. lock to a specific builder-python tag. That jenkins-x repo doesn't tag the latest release with "latest", so we have to specify the actual latest version number ourselves to get the most recent updates.
3. Disable daily auto builds. No point in auto builds if we're never using a newer base image.

We could have a script to find the latest release number on docker hub, but I propose that locking the base image version we use prevents breaking changes being introduced. I propose we manually update the jenkinsxio/builder-python version this uses every time we do `jx upgrade platform`. We should probably also use https://github.com/jenkins-x/jenkins-x-builders instead of singling out builder-python. 